### PR TITLE
Fix PIFDumper output directory 

### DIFF
--- a/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
@@ -55,10 +55,6 @@ PIFDumper::PIFDumper(string filename) :
 
 void PIFDumper::init(Simulator *simulator, CC3DXMLElement *_xmlData) {
 	
-	//frequency=1;//CHECK HOW THIS IS HANDLED
-
-   //frequency=frequency;
-
    potts = simulator->getPotts();
    
    ostringstream numStream;
@@ -119,14 +115,12 @@ void PIFDumper::start() {
 
 
 void PIFDumper::update(CC3DXMLElement *_xmlData, bool _fullInitFlag){
-   
-   //Check how this is handled 
-	//frequency=frequency;
+
+   // Frequency is handled at a higher level, no need to handle it here.
 	pifname=_xmlData->getFirstElement("PIFName")->getText();
 	if(_xmlData->findElement("PIFFileExtension"))
 		pifFileExtension=_xmlData->getFirstElement("PIFFileExtension")->getText();
 
-	//frequency=1;
 }
 
 std::string PIFDumper::toString(){

--- a/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
@@ -56,6 +56,8 @@ PIFDumper::PIFDumper(string filename) :
 void PIFDumper::init(Simulator *simulator, CC3DXMLElement *_xmlData) {
 	
    potts = simulator->getPotts();
+
+   sim = simulator;
    
    ostringstream numStream;
    string numString;
@@ -118,6 +120,11 @@ void PIFDumper::update(CC3DXMLElement *_xmlData, bool _fullInitFlag){
 
    // Frequency is handled at a higher level, no need to handle it here.
 	pifname=_xmlData->getFirstElement("PIFName")->getText();
+   string basePath = sim->getBasePath();
+   if (basePath != "") {
+      pifname = basePath + "/" + pifname;
+   }
+
 	if(_xmlData->findElement("PIFFileExtension"))
 		pifFileExtension=_xmlData->getFirstElement("PIFFileExtension")->getText();
 

--- a/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.cpp
@@ -118,12 +118,12 @@ void PIFDumper::start() {
 
 void PIFDumper::update(CC3DXMLElement *_xmlData, bool _fullInitFlag){
 
-   // Frequency is handled at a higher level, no need to handle it here.
+	// Frequency is handled at a higher level, no need to handle it here.
 	pifname=_xmlData->getFirstElement("PIFName")->getText();
-   string basePath = sim->getBasePath();
-   if (basePath != "") {
-      pifname = basePath + "/" + pifname;
-   }
+	string basePath = sim->getBasePath();
+	if (basePath != "") {
+		pifname = basePath + "/" + pifname;
+	}
 
 	if(_xmlData->findElement("PIFFileExtension"))
 		pifFileExtension=_xmlData->getFirstElement("PIFFileExtension")->getText();

--- a/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.h
+++ b/CompuCell3D/core/CompuCell3D/steppables/PIFDumper/PIFDumper.h
@@ -37,6 +37,7 @@ namespace CompuCell3D {
   class CellTypePlugin;
   class PIFDUMPER_EXPORT PIFDumper : public Steppable {
     Potts3D *potts;
+    Simulator *sim;
 
     std::string pifname;
     int numDigits;


### PR DESCRIPTION
Would previously output piff files in the installation directory instead of simulation directory as mentioned in https://github.com/CompuCell3D/CompuCell3D/issues/18.
