### PR TITLE
Fixes a NameError bug

### DIFF
--- a/CompuCell3D/core/pythonSetupScripts/PySteppables.py
+++ b/CompuCell3D/core/pythonSetupScripts/PySteppables.py
@@ -1258,8 +1258,8 @@ class SteppableBasePy(SteppablePy,SBMLSolverHelper):
             fieldNames  = self.chemotaxisPlugin.getFieldNamesWithChemotaxisData( sourceCell )
             
             for fieldName in fieldNames:                
-                source_chd=chemotaxisPlugin.getChemotaxisData(sourceCell,fieldName)
-                target_chd=chemotaxisPlugin.addChemotaxisData(targetCell,fieldName)
+                source_chd=self.chemotaxisPlugin.getChemotaxisData(sourceCell,fieldName)
+                target_chd=self.chemotaxisPlugin.addChemotaxisData(targetCell,fieldName)
                 
                 target_chd.setLambda( source_chd.getLambda() )
                 target_chd.saturationCoef = source_chd.saturationCoef


### PR DESCRIPTION
When using the Chemotaxis Plugin where cells undergo mitosis, you see the following error:

   NameError: global name 'chemotaxisPlugin' is not defined

This fixes it.