### PR TITLE
Quick-Fix Issue #53 : Reopening displays previously opened random files

### DIFF
--- a/CompuCell3D/Twedit++5/Configuration.py
+++ b/CompuCell3D/Twedit++5/Configuration.py
@@ -26,7 +26,7 @@ class Configuration:
         self.defaultConfigs["WrapLines"] = False
         self.defaultConfigs["ShowWrapSymbol"] = False
         self.defaultConfigs["DontShowWrapLinesWarning"] = False
-        self.defaultConfigs["RestoreTabsOnStartup"] = True
+        self.defaultConfigs["RestoreTabsOnStartup"] = False
         self.defaultConfigs["EnableAutocompletion"] = False
         self.defaultConfigs["EnableQuickTextDecoding"] = True
         self.defaultConfigs["AutocompletionThreshold"] = 2

--- a/CompuCell3D/Twedit++5/EditorWindow.py
+++ b/CompuCell3D/Twedit++5/EditorWindow.py
@@ -915,6 +915,7 @@ class EditorWindow(QMainWindow):
         """
             restores tabs based on the last saved session
         """
+ 
         fileList = self.configuration.setting("ListOfOpenFilesAndPanels")
         for i in range(0, len(fileList), 2):
             panel = int(fileList[i + 1])


### PR DESCRIPTION
Setting default value for "Restore Tabs on Startup" to False.