### PR TITLE
Fixed no update of screen update frequency from GUI preferences

### DIFF
--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -556,6 +556,8 @@ def main_loop_player(sim, simthread=None, steppable_registry=None):
     if init_using_restart_snapshot_enabled:
         steppable_registry.restart_steering_panel()
 
+    simthread.setScreenUpdateFrequency()
+
     cur_step = beginning_step
 
     while cur_step < sim.getNumSteps():

--- a/cc3d/player5/Simulation/SimulationThread.py
+++ b/cc3d/player5/Simulation/SimulationThread.py
@@ -238,6 +238,13 @@ class SimulationThread(QtCore.QThread):
     def getScreenUpdateFrequency(self):
         return self.screenUpdateFrequency
 
+    def setScreenUpdateFrequency(self):
+        import cc3d.player5.Configuration as Configuration
+        try:
+            self.screenUpdateFrequency = Configuration.getSetting("ScreenUpdateFrequency")
+        except:
+            print('SIMTHREAD: Could not access configuration.')
+
     def getImageOutputFlag(self):
         return self.imageOutputFlag
 


### PR DESCRIPTION
GUI fix: changing screen update frequency in preferences had no effect. Simple method added to SimulationThread updates corresponding member from configuration database if accessible. Call the method before resuming simulation. 