### PR TITLE
Added shared dictionary to steppable base, for easy data sharing between steppables

### DIFF
--- a/cc3d/CompuCellSetup/persistent_globals.py
+++ b/cc3d/CompuCellSetup/persistent_globals.py
@@ -69,6 +69,9 @@ class PersistentGlobals:
         self.steering_param_dict = OrderedDict()
         self.steering_panel_synchronizer = Lock()
 
+        # dictionary holding shared variables between steppables
+        self.shared_steppable_vars = {}
+
     def add_steering_panel(self, panel_data: dict):
         """
         Adds steering panel if simulation is run using player

--- a/cc3d/core/PySteppables.py
+++ b/cc3d/core/PySteppables.py
@@ -207,6 +207,7 @@ class SteppableBasePy(SteppablePy, SBMLSolverHelper):
         self.mcs = -1
         # {plot_name:plotWindow  - pW object}
         self.plot_dict = {}
+        self.shared_steppable_vars = {}
 
         # {field_name:FieldVisData } -  used to keep track of simple cell tracking visualizations
         self.tracking_field_vis_dict = {}
@@ -299,6 +300,7 @@ class SteppableBasePy(SteppablePy, SBMLSolverHelper):
                 # setattr(self, type_name.upper(), type_id)
 
         self.fetch_loaded_plugins()
+        self.shared_steppable_vars = persistent_globals.shared_steppable_vars
 
     def fetch_loaded_plugins(self) -> None:
         """


### PR DESCRIPTION
More compact solution to [data sharing between steppables](https://pythonscriptingmanual.readthedocs.io/en/latest/passing_information_between_steppables.html). All steppables can access the same dictionary through the attribute `shared_steppable_vars`. 