### PR TITLE
Volume parameters initialized from XML if not specified in steppable

### DIFF
--- a/CompuCell3D/core/CompuCell3D/plugins/Volume/VolumePlugin.h
+++ b/CompuCell3D/core/CompuCell3D/plugins/Volume/VolumePlugin.h
@@ -67,8 +67,11 @@ namespace CompuCell3D {
 		double changeEnergyByCellId(const Point3D &pt, const CellG *newCell,const CellG *oldCell);
 		double customExpressionFunction(double _lambdaVolume,double _targetVolume, double _volumeBefore,double _volumeAfter);
 
+		void initializeCellVolumeParams();
+		bool cellVolumeParamsInitialized;
+
 	public:
-		VolumePlugin():potts(0),energyExpressionDefined(false),pUtils(0),pluginName("Volume"){};
+		VolumePlugin():potts(0),energyExpressionDefined(false),pUtils(0),pluginName("Volume"),cellVolumeParamsInitialized(false){};
 		virtual ~VolumePlugin();
 
 		// SimObject interface


### PR DESCRIPTION
Per JAG's request: CellG instance members `targetVolume` and `lambdaVolume` should be initialized based on XML. To accommodate setting in steppable `start` methods, I added on-the-fly initialization at first call to `changeEnergy` to populate instances with values according to whatever is specified in XML by type (if anything). So the precedence is `steppable.start() assignments by cell > XML spec by type > default = 0` for both members. 

The only limitation is that if nonzero member values are specified in XML for a type and both are set to zero during steppable `start` for a CellG instance of that type, the members of the instance will be overwritten according to the XML during the first step. However, this seems like an unlikely scenario. 