### PR TITLE
Fixed missing extra solver calls in ReactionDiffusionSolverFE

### DIFF
--- a/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.cpp
@@ -121,7 +121,7 @@ void ReactionDiffusionSolverFE::Scale(std::vector<float> const &maxDiffConstVec,
     }
 
     //calculate maximumNumber Of calls to the diffusion solver
-    int maxNumberOfDiffusionCalls = *max_element(scalingExtraMCSVec.begin(), scalingExtraMCSVec.end());
+    maxNumberOfDiffusionCalls = *max_element(scalingExtraMCSVec.begin(), scalingExtraMCSVec.end());
 
     if (maxNumberOfDiffusionCalls == 0)
         return;


### PR DESCRIPTION
Declaration of `maxNumberOfDiffusionCalls` as a temporary when setting was preventing extra integration calls from being executed. So all relevant parameters (diffusion coefficients, secretion rates, etc.) were being scaled for extra steps that were never executed. 