### PR TITLE
Fixed player issue when sim.cleanAfterSimulation() gets called while …

### DIFF
--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -626,7 +626,6 @@ def main_loop_player(sim, simthread=None, steppable_registry=None):
         simthread.waitForPlayerTaskToFinish()
         steppable_registry.finish()
         sim.cleanAfterSimulation()
-        simthread.sendStopSimulationRequest()
         simthread.simulationFinishedPostEvent(True)
         steppable_registry.clean_after_simulation()
 

--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -621,17 +621,12 @@ def main_loop_player(sim, simthread=None, steppable_registry=None):
         # simthread.emitFinishRequest()
         # # then we wait for GUI thread to unlock the finishMutex - it will only happen when all tasks
         # in the GUI thread are completed (especially those that need simulator object to stay alive)
-        # simthread.finishMutex.lock()
-        # simthread.finishMutex.unlock()
-        # # at this point GUI thread finished all the tasks for which simulator had to stay alive
-        # and we can proceed to destroy simulator
-        #
-        # sim.finish()
-        # if sim.getRecentErrorMessage() != "":
-        #     raise CC3DCPlusPlusError(sim.getRecentErrorMessage())
         print("CALLING FINISH")
+
+        simthread.waitForPlayerTaskToFinish()
         steppable_registry.finish()
         sim.cleanAfterSimulation()
+        simthread.sendStopSimulationRequest()
         simthread.simulationFinishedPostEvent(True)
         steppable_registry.clean_after_simulation()
 


### PR DESCRIPTION
…player still drawing. e.g. if field refresh frequency is set to 10 MCS but we run 11MCS we observed crash at the end of 11th step but not if we ran e.g. 20 or 30 steps