### PR TITLE
Feature/issue 318

### DIFF
--- a/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
@@ -1207,8 +1207,24 @@ FIELD3DEXTENDER(Field3D<int>,int)
       }
    }
   
+%}
+
+
+%inline %{
+
+    std::vector<std::string> getConcentrationFieldNames(CompuCell3D::Simulator & simulator) {
+        std::map<std::string, Field3D<float>*> & fieldMap = simulator.getConcentrationFieldNameMap();
+        std::map<std::string, Field3D<float>*>::iterator mitr;
+        std::vector<std::string> field_names;
+        for (mitr = fieldMap.begin(); mitr != fieldMap.end(); ++mitr)
+            field_names.push_back(mitr->first);
+        
+        return field_names;
+
+    }
 
 %}
+
 
 %inline %{
 

--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -15,6 +15,7 @@ import weakref
 from cc3d import CompuCellSetup
 from cc3d.core import RestartManager
 from cc3d.CompuCellSetup.simulation_utils import check_for_cpp_errors
+from cc3d.core.Validation.sanity_checkers import validate_cc3d_entity_identifier
 
 
 # -------------------- legacy API emulation ----------------------------------------
@@ -383,12 +384,22 @@ def store_screenshots(cur_step: int) -> None:
         screenshot_manager.output_screenshots(mcs=cur_step)
 
 
-
-
 def extra_init_simulation_objects(sim, simthread, init_using_restart_snapshot_enabled=False):
+    """
+    Performs extra initializations. Also checks for validity of concentration field names (those defined in C++)
+    :param sim:
+    :param simthread:
+    :param init_using_restart_snapshot_enabled:
+    :return:
+    """
 
     # after all xml steppables and plugins have been loaded we call extraInit to complete initialization
     sim.extraInit()
+    concentration_field_names = CompuCell.getConcentrationFieldNames(sim)
+    for conc_field_name in concentration_field_names:
+        validate_cc3d_entity_identifier(entity_identifier=conc_field_name,
+                                        entity_type_label='Concentration Field Label')
+
     # passing output directory to simulator object
     sim.setOutputDirectory(CompuCellSetup.persistent_globals.output_directory)
     # simthread.preStartInit()

--- a/cc3d/core/FieldRegistry.py
+++ b/cc3d/core/FieldRegistry.py
@@ -2,6 +2,7 @@ from cc3d.core.enums import *
 from cc3d import CompuCellSetup
 import numpy as np
 from .ExtraFieldAdapter import ExtraFieldAdapter
+from cc3d.core.Validation.sanity_checkers import validate_cc3d_entity_identifier
 
 
 class FieldRegistry:
@@ -35,7 +36,7 @@ class FieldRegistry:
         :return:
         """
         # todo - need to add mechanism to inform player about new field
-
+        validate_cc3d_entity_identifier(entity_identifier=field_name, entity_type_label='visualization field')
         field_adapter = self.schedule_field_creation(field_name=field_name, field_type=field_type)
 
         if self.enable_ad_hoc_field_creation:
@@ -122,14 +123,14 @@ class FieldRegistry:
         if field_adapter is None:
             return
 
-        fieldNP = np.zeros(shape=(self.dim.x, self.dim.y, self.dim.z, 3), dtype=np.float32)
-        ndarrayAdapter = self.get_field_storage().createVectorFieldPy(self.dim, field_name)
+        field_np = np.zeros(shape=(self.dim.x, self.dim.y, self.dim.z, 3), dtype=np.float32)
+        ndarray_adapter = self.get_field_storage().createVectorFieldPy(self.dim, field_name)
         # initializing  numpyAdapter using numpy array (copy dims and data ptr)
-        ndarrayAdapter.initFromNumpy(fieldNP)
-        self.addNewField(ndarrayAdapter, field_name, VECTOR_FIELD)
-        self.addNewField(fieldNP, field_name + '_npy', VECTOR_FIELD_NPY)
+        ndarray_adapter.initFromNumpy(field_np)
+        self.addNewField(ndarray_adapter, field_name, VECTOR_FIELD)
+        self.addNewField(field_np, field_name + '_npy', VECTOR_FIELD_NPY)
 
-        field_adapter.set_ref(fieldNP)
+        field_adapter.set_ref(field_np)
 
     def create_vector_field_cell_level(self, field_name: str) -> None:
         """
@@ -156,6 +157,7 @@ class FieldRegistry:
         """
 
         for field_name, field_adapter in self.__fields_to_create.items():
+
             try:
                 field_creating_fcn = self.field_creating_fcns[field_adapter.field_type]
             except KeyError:

--- a/cc3d/core/PySteppables.py
+++ b/cc3d/core/PySteppables.py
@@ -21,6 +21,7 @@ from cc3d.core.SteeringParam import SteeringParam
 from copy import deepcopy
 from math import sqrt
 from cc3d.core.numerics import *
+from cc3d.core.Validation.sanity_checkers import validate_cc3d_entity_identifier
 
 
 class SteppablePy:
@@ -753,18 +754,7 @@ class SteppableBasePy(SteppablePy, SBMLSolverHelper):
         :param type_id:{str}
         :return:
         """
-        alphanumeric_underscore_regex = r'^\w+$'
-
-        if cell_type_name.isspace() or not len(cell_type_name.strip()):
-            raise AttributeError(f'cell type "{cell_type_name}" contains whitespaces')
-
-        if not cell_type_name[0].isalpha():
-            raise AttributeError(f'Invalid cell type "{cell_type_name}" . Type name must start with a letter')
-
-        if not re.match(alphanumeric_underscore_regex, cell_type_name):
-            raise AttributeError(f'Invalid character detected in a cell type "{cell_type_name}" . '
-                                 f'Type name must consist of alphanumeric characters and (optionally) an underscore')
-
+        validate_cc3d_entity_identifier(cell_type_name, entity_type_label='cell type')
         cell_type_name_attr_list = [cell_type_name.upper(), f't_{cell_type_name}']
 
         for cell_type_name_attr in cell_type_name_attr_list:

--- a/cc3d/core/Validation/sanity_checkers.py
+++ b/cc3d/core/Validation/sanity_checkers.py
@@ -1,0 +1,29 @@
+import re
+
+
+def validate_cc3d_entity_identifier(entity_identifier: str, entity_type_label:str= ''):
+    """
+    Checks if entity identifier conforms to CC3D naming standards. Cell types names, fields etc
+    have to start from the letter and contain only alphanumeric strings with no spaces or charcters that could be
+    interpreted as syntax elements in python . Function does not return anything but raises AttributeError
+    exception if it detects inappropriate identifier
+    :param entity_identifier: identifier to check
+    :param entity_type_label: optional string that helps print out more-targeted error message
+    :return:
+    """
+    alphanumeric_underscore_regex = r'^\w+$'
+
+    if not entity_type_label:
+        entity_type_label = 'identifier'
+
+    if entity_identifier.isspace() or not len(entity_identifier.strip()):
+        raise AttributeError(f'{entity_type_label} "{entity_identifier}" contains whitespaces')
+
+    if not entity_identifier[0].isalpha():
+        raise AttributeError(f'Invalid {entity_type_label} "{entity_identifier}" . {entity_type_label} '
+                             f'must start with a letter')
+
+    if not re.match(alphanumeric_underscore_regex, entity_identifier):
+        raise AttributeError(f'Invalid character detected in a {entity_type_label} "{entity_identifier}" . '
+                             f'{entity_type_label} must consist of alphanumeric characters and (optionally) '
+                             f'an underscore')

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -357,6 +357,13 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
     def on_fieldAddPB_clicked(self):
 
         field_name = str(self.fieldNameLE.text()).strip()
+
+        try:
+            validate_cc3d_entity_identifier(field_name, entity_type_label='field label')
+        except AttributeError as e:
+            self.display_invalid_entity_label_message(error_message=str(e))
+            return
+
         rows = self.fieldTable.rowCount()
 
         if field_name == "":

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -10,6 +10,7 @@ from . import ui_newsimulationwizard
 from collections import OrderedDict
 import cc3d
 from cc3d.core.XMLUtils import ElementCC3D
+from cc3d.core.Validation.sanity_checkers import validate_cc3d_entity_identifier
 from cc3d.twedit5.Plugins.CC3DMLGenerator.CC3DMLGeneratorBase import CC3DMLGeneratorBase
 from .CC3DPythonGenerator import CC3DPythonGenerator
 
@@ -46,6 +47,16 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
 
         if sys.platform.startswith('win'):
             self.setWizardStyle(QWizard.ClassicStyle)
+
+    def display_invalid_entity_label_message(self, error_message):
+        """
+        Displays warning about invalid identifier
+        :param error_message:
+        :return:
+        """
+
+        QMessageBox.warning(self, 'Invalid Identifier', error_message)
+
 
     def keyPressEvent(self, event):
 
@@ -262,6 +273,11 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
     def on_cellTypeAddPB_clicked(self):
 
         cell_type = str(self.cellTypeLE.text()).strip()
+        try:
+            validate_cc3d_entity_identifier(cell_type, entity_type_label='cell type')
+        except AttributeError as e:
+            self.display_invalid_entity_label_message(error_message=str(e))
+            return
 
         rows = self.cellTypeTable.rowCount()
 


### PR DESCRIPTION
This addresses https://github.com/CompuCell3D/CompuCell3D/issues/318. We want to pre-check cell type and field names to be free of any characters that can be interpreted as python syntax. Checks are done in twedit++ and also before simulation starts running in case user writes simulation by hand 