### PR TITLE
General class for derived properties

### DIFF
--- a/CompuCell3D/core/CompuCell3D/CMakeLists.txt
+++ b/CompuCell3D/core/CompuCell3D/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(SRCS
   PluginManager.cpp
   Simulator.cpp
   ClassRegistry.cpp
+  DerivedProperty.cpp
   PottsParseData.cpp
   ParserStorage.cpp
   # CustomStreamBuffers.cpp
@@ -144,6 +145,7 @@ endif(${CMAKE_SYSTEM_NAME} STREQUAL Windows)
 INSTALL_FILES(/include/CompuCell3D/CompuCell3D .h
   ClassRegistry
   CompuCellLibDLLSpecifier  
+  DerivedProperty
   ParseData
   Parser
   ParserStorage

--- a/CompuCell3D/core/CompuCell3D/DerivedProperty.cpp
+++ b/CompuCell3D/core/CompuCell3D/DerivedProperty.cpp
@@ -1,0 +1,23 @@
+/*************************************************************************
+ *    CompuCell - A software framework for multimodel simulations of     *
+ * biocomplexity problems Copyright (C) 2003 University of Notre Dame,   *
+ *                             Indiana                                   *
+ *                                                                       *
+ * This program is free software; IF YOU AGREE TO CITE USE OF CompuCell  *
+ *  IN ALL RELATED RESEARCH PUBLICATIONS according to the terms of the   *
+ *  CompuCell GNU General Public License RIDER you can redistribute it   *
+ * and/or modify it under the terms of the GNU General Public License as *
+ *  published by the Free Software Foundation; either version 2 of the   *
+ *         License, or (at your option) any later version.               *
+ *                                                                       *
+ * This program is distributed in the hope that it will be useful, but   *
+ *      WITHOUT ANY WARRANTY; without even the implied warranty of       *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU    *
+ *             General Public License for more details.                  *
+ *                                                                       *
+ *  You should have received a copy of the GNU General Public License    *
+ *     along with this program; if not, write to the Free Software       *
+ *      Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.        *
+ *************************************************************************/
+
+#include "DerivedProperty.h"

--- a/CompuCell3D/core/CompuCell3D/DerivedProperty.h
+++ b/CompuCell3D/core/CompuCell3D/DerivedProperty.h
@@ -1,0 +1,61 @@
+/*************************************************************************
+*    CompuCell - A software framework for multimodel simulations of     *
+* biocomplexity problems Copyright (C) 2003 University of Notre Dame,   *
+*                             Indiana                                   *
+*                                                                       *
+* This program is free software; IF YOU AGREE TO CITE USE OF CompuCell  *
+*  IN ALL RELATED RESEARCH PUBLICATIONS according to the terms of the   *
+*  CompuCell GNU General Public License RIDER you can redistribute it   *
+* and/or modify it under the terms of the GNU General Public License as *
+*  published by the Free Software Foundation; either version 2 of the   *
+*         License, or (at your option) any later version.               *
+*                                                                       *
+* This program is distributed in the hope that it will be useful, but   *
+*      WITHOUT ANY WARRANTY; without even the implied warranty of       *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU    *
+*             General Public License for more details.                  *
+*                                                                       *
+*  You should have received a copy of the GNU General Public License    *
+*     along with this program; if not, write to the Free Software       *
+*      Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.        *
+*************************************************************************/
+#ifndef DERIVEDPROPERTY_H
+#define DERIVEDPROPERTY_H
+
+namespace CompuCell3D {
+
+	/**
+	DerivedProperty: Derived properties that mimic the behavior of Python properties in C++
+	Written by T.J. Sego, Ph.D.
+	9/12/2020
+
+	The DerivedProperty returns the value of the property on demand according to a function 
+	that defines the DerivedProperty. All requisite information to calculate the current 
+	value of a DerivedProperty must be intrinsic to the instance of the parent class.
+
+	For CC3D Python support, follow the procedure of existing implementations 
+	using the SWIG macro DERIVEDPROPERTYEXTENSORPY in CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
+	*/
+
+	template <typename ParentType, typename PropertyType, PropertyType(ParentType::*PropertyFunction)()>
+	class DerivedProperty {
+
+		// Parent object with this derived property as a member
+		ParentType *obj;
+
+	public:
+
+		DerivedProperty() {}
+		DerivedProperty(ParentType *_obj) :
+			obj(_obj)
+		{}
+		~DerivedProperty() { obj = 0; }
+
+		// Pretend to be a value
+		operator PropertyType() const { return (obj->*PropertyFunction)(); }
+
+	};
+
+}
+
+#endif

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
@@ -61,6 +61,7 @@ CellG::CellG() :
 
 {
 	DerivedProperty<CellG, float, &CellG::getPressure> pressure(this);
+	DerivedProperty<CellG, float, &CellG::getSurfaceTension> surfaceTension(this);
 }
 
 float CellG::getPressure() { return 2.0 * lambdaVolume * (volume - targetVolume); }

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
@@ -64,3 +64,5 @@ CellG::CellG() :
 }
 
 float CellG::getPressure() { return 2.0 * lambdaVolume * (volume - targetVolume); }
+
+float CellG::getSurfaceTension() { return 2.0 * lambdaSurface * (surface - targetSurface); }

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
@@ -62,8 +62,11 @@ CellG::CellG() :
 {
 	DerivedProperty<CellG, float, &CellG::getPressure> pressure(this);
 	DerivedProperty<CellG, float, &CellG::getSurfaceTension> surfaceTension(this);
+	DerivedProperty<CellG, float, &CellG::getClusterSurfaceTension> clusterSurfaceTension(this);
 }
 
 float CellG::getPressure() { return 2.0 * lambdaVolume * (volume - targetVolume); }
 
 float CellG::getSurfaceTension() { return 2.0 * lambdaSurface * (surface - targetSurface); }
+
+float CellG::getClusterSurfaceTension() { return 2.0 * lambdaClusterSurface * (clusterSurface - targetClusterSurface); }

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.cpp
@@ -21,3 +21,46 @@
  *************************************************************************/
 
 #include "Cell.h"
+
+using namespace CompuCell3D;
+
+CellG::CellG() :
+	volume(0),
+	targetVolume(0.0),
+	lambdaVolume(0.0),
+	surface(0),
+	targetSurface(0.0),
+	lambdaSurface(0.0),
+	clusterSurface(0.0),
+	targetClusterSurface(0.0),
+	lambdaClusterSurface(0.0),
+	type(0),
+	xCM(0), yCM(0), zCM(0),
+	xCOM(0), yCOM(0), zCOM(0),
+	xCOMPrev(0), yCOMPrev(0), zCOMPrev(0),
+	iXX(0), iXY(0), iXZ(0), iYY(0), iYZ(0), iZZ(0),
+	lX(0.0),
+	lY(0.0),
+	lZ(0.0),
+	lambdaVecX(0.0),
+	lambdaVecY(0.0),
+	lambdaVecZ(0.0),
+	flag(0),
+	id(0),
+	clusterId(0),
+	fluctAmpl(-1.0),
+	lambdaMotility(0.0),
+	biasVecX(1.0),
+	biasVecY(0.0),
+	biasVecZ(0.0),
+	connectivityOn(false),
+	extraAttribPtr(0),
+	pyAttrib(0)
+	//test_biasV
+
+
+{
+	DerivedProperty<CellG, float, &CellG::getPressure> pressure(this);
+}
+
+float CellG::getPressure() { return 2.0 * lambdaVolume * (volume - targetVolume); }

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
@@ -86,11 +86,15 @@ namespace CompuCell3D {
 	   float getPressure();
 	   // Function defining the value of derived property: surface tension
 	   float getSurfaceTension();
+	   // Function defining the value of derived property: cluster surface tension
+	   float getClusterSurfaceTension();
 
 	   // Internal pressure
 	   DerivedProperty<CellG, float, &CellG::getPressure> pressure;
 	   // Surface tension
 	   DerivedProperty<CellG, float, &CellG::getSurfaceTension> surfaceTension;
+	   // Cluster surface tension
+	   DerivedProperty<CellG, float, &CellG::getClusterSurfaceTension> clusterSurfaceTension;
 
    };
 

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
@@ -24,6 +24,7 @@
 #define CELL_H
 
 #include <vector>
+#include <CompuCell3D\DerivedProperty.h>
 
 #ifndef PyObject_HEAD
 struct _object; //forward declare
@@ -41,42 +42,8 @@ namespace CompuCell3D {
    class CellG{
    public:
       typedef unsigned char CellType_t;
-      CellG():
-        volume(0),
-        targetVolume(0.0),
-        lambdaVolume(0.0),
-        surface(0),
-        targetSurface(0.0),
-        lambdaSurface(0.0),
-		clusterSurface(0.0),
-		targetClusterSurface(0.0),
-		lambdaClusterSurface(0.0),
-        type(0),
-        xCM(0),yCM(0),zCM(0),
-		xCOM(0),yCOM(0),zCOM(0),
-		xCOMPrev(0),yCOMPrev(0),zCOMPrev(0),
-        iXX(0), iXY(0), iXZ(0), iYY(0), iYZ(0), iZZ(0),
-        lX(0.0),
-        lY(0.0),
-        lZ(0.0),
-        lambdaVecX(0.0),
-        lambdaVecY(0.0),
-        lambdaVecZ(0.0),
-        flag(0),
-        id(0),
-        clusterId(0),
-		fluctAmpl(-1.0),
-		lambdaMotility(0.0),
-		biasVecX(1.0),
-		biasVecY(0.0),
-		biasVecZ(0.0),
-		connectivityOn(false),
-        extraAttribPtr(0),
-        pyAttrib(0)
-		//test_biasV
+	  CellG();
 
-
-      {}
       long volume;
       float targetVolume;
       float lambdaVolume;
@@ -110,6 +77,17 @@ namespace CompuCell3D {
       BasicClassGroup *extraAttribPtr;
 
       PyObject *pyAttrib;
+
+	  // Derived properties
+
+   public:
+
+	   // Function defining the value of derived property: pressure
+	   float getPressure();
+
+	   // Internal pressure
+	   DerivedProperty<CellG, float, &CellG::getPressure> pressure;
+
    };
 
 

--- a/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
+++ b/CompuCell3D/core/CompuCell3D/Potts3D/Cell.h
@@ -84,9 +84,13 @@ namespace CompuCell3D {
 
 	   // Function defining the value of derived property: pressure
 	   float getPressure();
+	   // Function defining the value of derived property: surface tension
+	   float getSurfaceTension();
 
 	   // Internal pressure
 	   DerivedProperty<CellG, float, &CellG::getPressure> pressure;
+	   // Surface tension
+	   DerivedProperty<CellG, float, &CellG::getSurfaceTension> surfaceTension;
 
    };
 

--- a/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
@@ -1448,3 +1448,5 @@ public:
 
 
 %include "CompuCellExtraDeclarations.i"
+
+%include "DerivedProperty.i"

--- a/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
@@ -26,3 +26,4 @@
 
 DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, pressure, getPressure)
 DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, surfaceTension, getSurfaceTension)
+DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, clusterSurfaceTension, getClusterSurfaceTension)

--- a/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
@@ -25,3 +25,4 @@
 // CellG DerivedProperties
 
 DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, pressure, getPressure)
+DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, surfaceTension, getSurfaceTension)

--- a/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
@@ -1,0 +1,23 @@
+// This macro performs Python-equivalent implementation of the C++ DerivedProperty
+// for a wrapped class
+// className: the name of the class with a DerivedProperty member; explicitly including the namespace of the class helps
+// propertyName: the name of the DerivedProperty member, exactly as it is defined in the class definition
+// accessorName: the name of the function that defines the value of the DerivedProperty; do not include its namespace
+%define DERIVEDPROPERTYEXTENSORPY(className, propertyName, accessorName)
+%extend className {
+	%pythoncode %{
+		def derived_property_get ## propertyName(self):
+			return self. ## accessorName()
+
+		__swig_getmethods__["propertyName"] = derived_property_get ## propertyName
+
+		def derived_property_set ## propertyName(self, _val):
+			raise AttributeError('Assignment of derived property propertyName is illegal.')
+
+		__swig_setmethods__["propertyName"] = derived_property_set ## propertyName
+
+		if _newclass : propertyName = property(derived_property_get ## propertyName, derived_property_set ## propertyName)
+
+	%}
+}
+%enddef

--- a/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/DerivedProperty.i
@@ -21,3 +21,7 @@
 	%}
 }
 %enddef
+
+// CellG DerivedProperties
+
+DERIVEDPROPERTYEXTENSORPY(CompuCell3D::CellG, pressure, getPressure)


### PR DESCRIPTION
Highlights: 

- New general class: DerivedProperty
- DerivedProperty members return a value like a member variable according to a member function evaluation defined on the parent class in C++ and Python
- A member function defining the value of a DerivedProperty is restricted to information intrinsic to its class
- New interface file collects all Python implementations and includes a macro that reduces implementation to a single line per DerivedProperty
- Implementations in this PR: CellG pressure, surface tension and cluster surface tension

Notes on future work: waiting on link class definition to define a link tension