### PR TITLE
Feature/graphics 3d fix

### DIFF
--- a/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractor.h
+++ b/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractor.h
@@ -91,7 +91,7 @@ namespace CompuCell3D{
 
 	    virtual bool fillScalarFieldData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec);
 
-		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr);
+		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr, bool extractOuterShellOnly=false);
 		virtual bool fillConFieldData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec);
 
 		void setVtkObj(void * _vtkObj);

--- a/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorBase.h
+++ b/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorBase.h
@@ -60,7 +60,7 @@ namespace CompuCell3D{
 
 		virtual bool fillScalarFieldCellLevelData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec){return false;}
 
-		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr){return std::vector<int>();}
+		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr, bool extractOuterShellOnly = false){return std::vector<int>();}
 		virtual bool fillConFieldData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec){return false;}
 
 	protected:

--- a/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorCML.cpp
+++ b/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorCML.cpp
@@ -1313,7 +1313,7 @@ bool FieldExtractorCML::fillVectorFieldCellLevelData3DHex(vtk_obj_addr_int_t _po
 
 
 //vector<int> FieldExtractorCML::fillCellFieldData3D(long _cellTypeArrayAddr){
-vector<int> FieldExtractorCML::fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr){
+vector<int> FieldExtractorCML::fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr, bool extractOuterShellOnly){
 	set<int> usedCellTypes;
 
 	vtkIntArray *cellTypeArray = (vtkIntArray *)_cellTypeArrayAddr;

--- a/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorCML.h
+++ b/CompuCell3D/core/pyinterface/PlayerPythonNew/FieldExtractorCML.h
@@ -87,7 +87,7 @@ namespace CompuCell3D{
 
 		virtual bool fillScalarFieldCellLevelData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec);
 
-		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr);
+		virtual std::vector<int> fillCellFieldData3D(vtk_obj_addr_int_t _cellTypeArrayAddr, vtk_obj_addr_int_t _cellIdArrayAddr, bool extractOuterShellOnly = false);
 		virtual bool fillConFieldData3D(vtk_obj_addr_int_t _conArrayAddr ,vtk_obj_addr_int_t _cellTypeArrayAddr, std::string _conFieldName,std::vector<int> * _typesInvisibeVec);
 
         virtual bool readVtkStructuredPointsData(vtk_obj_addr_int_t _structuredPointsReaderAddr);

--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -580,6 +580,10 @@ def main_loop_player(sim, simthread=None, steppable_registry=None):
 
     cur_step = beginning_step
 
+    # initial drawing - we use mcs = -2 as a sentinel for mcs right after start function of steppables is completed
+    simthread.loopWork(-2)
+    simthread.loopWorkPostEvent(-2)
+
     while cur_step < sim.getNumSteps():
         simthread.beforeStep(_mcs=cur_step)
         if simthread.getStopSimulation() or CompuCellSetup.persistent_globals.user_stop_simulation_flag:

--- a/cc3d/core/BasicSimulationData.py
+++ b/cc3d/core/BasicSimulationData.py
@@ -7,3 +7,4 @@ class BasicSimulationData():
         self.fieldDim = None
         self.cell_types_used = None
         self.numberOfSteps = 0
+        self.current_step = 0

--- a/cc3d/core/GraphicsOffScreen/MVCDrawModel3D.py
+++ b/cc3d/core/GraphicsOffScreen/MVCDrawModel3D.py
@@ -164,10 +164,6 @@ class MVCDrawModel3D(MVCDrawModelBase):
 
         field_dim = self.currentDrawingParameters.bsd.fieldDim
 
-        hex_flag = False
-        lattice_type_str = self.get_lattice_type_str()
-        # if lattice_type_str.lower() == 'hexagonal':
-        #     hex_flag = True
         hex_flag = self.is_lattice_hex(drawing_params=drawing_params)
 
         cell_type_image_data = vtk.vtkImageData()

--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -1907,7 +1907,11 @@ class SimpleTabView(MainArea, SimpleViewManager):
                 self.__pauseSim()
         self.simulation.drawMutex.lock()
 
-        self.__step = self.simulation.getCurrentStep()
+        start_completed_no_mcs = False
+        if self.__step < 0:
+            start_completed_no_mcs = True
+        else:
+            self.__step = self.simulation.getCurrentStep()
 
         if self.mysim:
 
@@ -1920,7 +1924,10 @@ class SimpleTabView(MainArea, SimpleViewManager):
                 graphics_frame.draw(self.basicSimulationData)
 
                 # show MCS in lower-left GUI
-                self.__updateStatusBar(self.__step)
+                if start_completed_no_mcs:
+                    self.__updateStatusBar('start')
+                else:
+                    self.__updateStatusBar(self.__step)
 
         self.simulation.drawMutex.unlock()
 
@@ -2019,14 +2026,13 @@ class SimpleTabView(MainArea, SimpleViewManager):
         '''
         self.warnings.setText(warning_text)
 
-    def __updateStatusBar(self, step):
-        '''
+    def __updateStatusBar(self, step: Union[int, str]) -> None:
+        """
         Updates status bar
-        :param step: int - current MCS
+        :param step:  - current MCS
         :return:
-        '''
-        self.mcSteps.setText("MC Step: %s" % step)
-        # self.conSteps.setText("Min: %s Max: %s" % conMinMax)
+        """
+        self.mcSteps.setText(f"MC Step: {step}")
 
     def __pauseSim(self):
         '''

--- a/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/SimpleTabView.py
@@ -143,6 +143,8 @@ class SimpleTabView(MainArea, SimpleViewManager):
 
         self.__fieldType = ("Cell_Field", FIELD_TYPES[0])
 
+        self.__step = 0
+
         self.output_step_max_items = 3
         self.step_output_list = []
 
@@ -213,6 +215,14 @@ class SimpleTabView(MainArea, SimpleViewManager):
         # Here we are checking for new version - notice we use check interval in order not to perform version checks
         # too often. Default check interval is 7 days
         self.check_version(check_interval=7)
+
+    @property
+    def current_step(self) -> int:
+        """
+        returns current mcs
+        :return:
+        """
+        return self.__step
 
     def update_recent_file_menu(self) -> None:
         """
@@ -1998,7 +2008,7 @@ class SimpleTabView(MainArea, SimpleViewManager):
             # for some reason cameras have to be initialized after drawing resized lattice
             # and draw function has to be repeated
             self.updateVisualization()
-
+        self.basicSimulationData.current_step = self.current_step
         __drawFieldFcn()
 
     def displayWarning(self, warning_text):


### PR DESCRIPTION
This PR addresses issues with "missing cells in 3D" https://github.com/CompuCell3D/CompuCell3D/issues/393. This happened only when NeighborTracker was enabled and was caused by "overly eager" optimization. Now when user choose drawing cell borders in 3D cell shell optimization (drawing only outermost shell of cells) is enabled . we do not choose to display borders in 3D thenn all the cells are shown (except you cannot see borders). We might want to revisit it later and have separate setting for cell shell optimization but for now this fix addresses the issue 