### PR TITLE
Make Types3DInvisible be only saved in the local settings and not in …

### DIFF
--- a/cc3d/player5/Configuration/__init__.py
+++ b/cc3d/player5/Configuration/__init__.py
@@ -52,7 +52,7 @@ class Configuration:
 
     globalOnlySettings = ['RecentSimulations', 'NumberOfRecentSimulations', 'OutputLocation', 'ProjectLocation',
                           'FloatingWindows', 'MainWindowSizeDefault', 'MainWindowSizeDefault', 'ScreenGeometry']
-    customOnlySettings = ['WindowsLayout']
+    customOnlySettings = ['WindowsLayout', 'Types3DInvisible']
 
     activeFieldNamesList = []
 

--- a/cc3d/player5/Graphics/GraphicsFrameWidget.py
+++ b/cc3d/player5/Graphics/GraphicsFrameWidget.py
@@ -296,8 +296,10 @@ class GraphicsFrameWidget(QtWidgets.QFrame):
 
         if invisible_types:
             scr_data.invisible_types = list([int(x) for x in invisible_types.split(',')])
+            if 0 not in scr_data.invisible_types:
+                scr_data.invisible_types = [0] + scr_data.invisible_types
         else:
-            scr_data.invisible_types = []
+            scr_data.invisible_types = [0]
 
     def render_repaint(self):
         """

--- a/cc3d/player5/Plugins/ViewManagerPlugins/ScreenshotManager.py
+++ b/cc3d/player5/Plugins/ViewManagerPlugins/ScreenshotManager.py
@@ -106,8 +106,11 @@ class ScreenshotManager(ScreenshotManagerCore):
 
         if invisible_types:
             scrData.invisible_types = list([int(x) for x in invisible_types.split(',')])
+            if 0 not in scrData.invisible_types:
+                scrData.invisible_types = [0] + scrData.invisible_types
+
         else:
-            scrData.invisible_types = []
+            scrData.invisible_types = [0]
 
     # called from GraphicsFrameWidget
     def add_2d_screenshot(self, _plotName, _plotType, _projection, _projectionPosition,


### PR DESCRIPTION
…global ones so that we do not pass this setting between new simulations

Addressed https://github.com/CompuCell3D/CompuCell3D/issues/394