### PR TITLE
fix/CellTypeColorMapModel

### DIFF
--- a/cc3d/player5/UI/CellTypeColorMapModel.py
+++ b/cc3d/player5/UI/CellTypeColorMapModel.py
@@ -77,7 +77,7 @@ class CellTypeColorMapModel(QtCore.QAbstractTableModel):
             try:
                 # return self.item_data[p_int].name
                 return self.item_data[p_int]
-            except IndexError:
+            except KeyError:
                 return QVariant()
 
         return QVariant()


### PR DESCRIPTION
Fix to occasional unhandled exception. 

`CellTypeColorMapModel.item_data` is an `OrderedDict`, so the exception to handle in `CellTypeColorMapModel.headerData` is a `KeyError`. 