### PR TITLE
Remove unimportant dev message

### DIFF
--- a/cc3d/core/XMLDomUtils.py
+++ b/cc3d/core/XMLDomUtils.py
@@ -60,7 +60,6 @@ class XMLElemAdapter:
             be_selective = True
         except (KeyError,AttributeError):
             be_selective = False
-            print('self.attribs_initialized does not exist')
 
         if not be_selective:
             self.__dict__[key] = value


### PR DESCRIPTION
Any reason we should keep this? In some cases, it prints long entries of the same message, which can be alarming. 