### PR TITLE
Add to_tuple to Dim3D and Point3D, with minor cleanup

### DIFF
--- a/CompuCell3D/core/CompuCell3D/Field3D/Dim3D.h
+++ b/CompuCell3D/core/CompuCell3D/Field3D/Dim3D.h
@@ -25,8 +25,6 @@
 
 #include "Point3D.h"
 
-//#include <XMLCereal/XMLSerializable.h>
-
 #include <string>
 
 namespace CompuCell3D {
@@ -44,63 +42,70 @@ namespace CompuCell3D {
     /// Copy constructor
     Dim3D(const Dim3D &dim) : Point3D(dim) {}  
 
-    Dim3D &operator=(const Dim3D pt) {
-      x = pt.x;
-      y = pt.y;
-      z = pt.z;
-      return *this;
-    }
+    Dim3D &operator=(const Dim3D pt);
 
     /** 
      * Add the coordinates of pt to this Point3D.
      */
-    Dim3D &operator+=(const Dim3D pt) {
-      x += pt.x;
-      y += pt.y;
-      z += pt.z;
-      return *this;
-    }
+    Dim3D &operator+=(const Dim3D pt);
 
     /** 
      * Subtract the coordinates of pt to this Point3D.
      */
-    Dim3D &operator-=(const Dim3D pt) {
-      x -= pt.x;
-      y -= pt.y;
-      z -= pt.z;
-      return *this;
-    }
+    Dim3D &operator-=(const Dim3D pt);
         
     /// Comparison operator
-    bool operator==(const Dim3D pt) const {
-      return (x == pt.x && y == pt.y && z == pt.z);
-    }
-    /// Not equal operator
-    bool operator!=(const Dim3D pt) const {
-		
-      return !(*this==pt);
-    }
-    
-   bool operator<(const Dim3D  _rhs) const{
-      return x < _rhs.x || (!(_rhs.x < x)&& y < _rhs.y)
-			||(!(_rhs.x < x)&& !(_rhs.y <y )&& z < _rhs.z);
-   }
-   short & operator[](int _idx){
-	   if(!_idx){
-			return x;
-	   }else if(_idx==1){
-			return y;
-	   }else { //there is no error checking here so in case user picks index out of range we return z coordinate
-			return z;
-	   }
-   }
+    bool operator==(const Dim3D pt) const { return (x == pt.x && y == pt.y && z == pt.z); }
 
-   friend std::ostream &operator<<(std::ostream &stream, const Dim3D &pt);
+    /// Not equal operator
+    bool operator!=(const Dim3D pt) const { return !(*this==pt); }
+    
+    bool operator<(const Dim3D  _rhs) const;
+
+    short & operator[](int _idx);
+
+    friend std::ostream &operator<<(std::ostream &stream, const Dim3D &pt);
   };
 
-    inline std::ostream &operator<<(std::ostream &stream, const Dim3D &pt) {
+  inline Dim3D &Dim3D::operator=(const Dim3D pt) {
+    x = pt.x;
+    y = pt.y;
+    z = pt.z;
+    return *this;
+  }
+
+  inline Dim3D &Dim3D::operator+=(const Dim3D pt) {
+    x += pt.x;
+    y += pt.y;
+    z += pt.z;
+    return *this;
+  }
+
+  inline Dim3D &Dim3D::operator-=(const Dim3D pt) {
+    x -= pt.x;
+    y -= pt.y;
+    z -= pt.z;
+    return *this;
+  }
+
+  inline bool Dim3D::operator<(const Dim3D  _rhs) const {
+    return x < _rhs.x || (!(_rhs.x < x)&& y < _rhs.y)
+    ||(!(_rhs.x < x)&& !(_rhs.y <y )&& z < _rhs.z);
+  }
+
+  inline std::ostream &operator<<(std::ostream &stream, const Dim3D &pt) {
     stream << '(' << pt.x << ',' << pt.y << ',' << pt.z << ')';
     return stream;
+  }
+
+  inline short & Dim3D::operator[](int _idx) {
+    if(!_idx){
+      return x;
+    }else if(_idx==1){
+      return y;
+    }else { //there is no error checking here so in case user picks index out of range we return z coordinate
+      return z;
+    }
   }
 
   /** 

--- a/CompuCell3D/core/CompuCell3D/Field3D/Point3D.cpp
+++ b/CompuCell3D/core/CompuCell3D/Field3D/Point3D.cpp
@@ -24,15 +24,3 @@
 using namespace CompuCell3D;
 
 #include <BasicUtils/BasicString.h>
-
-//#include <XMLCereal/XMLPullParser.h>
-//#include <XMLCereal/XMLSerializer.h>
-
-//void Point3D::readXML(XMLPullParser &in) {
-//  x = BasicString::parseUInteger(in.getAttribute("x").value);
-//  y = BasicString::parseUInteger(in.getAttribute("y").value);
-//  z = BasicString::parseUInteger(in.getAttribute("z").value);
-//}
-//
-//void Point3D::writeXML(XMLSerializer &out) {
-//}

--- a/CompuCell3D/core/CompuCell3D/Field3D/Point3D.h
+++ b/CompuCell3D/core/CompuCell3D/Field3D/Point3D.h
@@ -23,8 +23,6 @@
 #ifndef POINT3D_H
 #define POINT3D_H
 
-//#include <XMLCereal/XMLSerializable.h>
-
 #include <BasicUtils/BasicString.h>
 
 #include <iostream>
@@ -35,7 +33,7 @@ namespace CompuCell3D {
    * A 3D point.
    * 
    */
-  class Point3D /*: public virtual XMLSerializable*/ {
+  class Point3D {
   public:
     short x;
     short y;
@@ -57,54 +55,54 @@ namespace CompuCell3D {
     /** 
      * Assignment operator.
      */    
-    Point3D &operator=(const Point3D pt) {
-      x = pt.x;
-      y = pt.y;
-      z = pt.z;
-      return *this;
-    }
+    Point3D &operator=(const Point3D pt);
 
     /** 
      * Add the coordinates of pt to this Point3D.
      */
-    Point3D &operator+=(const Point3D pt) {
-      x += pt.x;
-      y += pt.y;
-      z += pt.z;
-      return *this;
-    }
+    Point3D &operator+=(const Point3D pt);
 
     /** 
      * Subtract the coordinates of pt to this Point3D.
      */
-    Point3D &operator-=(const Point3D pt) {
-      x -= pt.x;
-      y -= pt.y;
-      z -= pt.z;
-      return *this;
-    }
+    Point3D &operator-=(const Point3D pt);
         
     /// Comparison operator
-    bool operator==(const Point3D pt) const {
-      return (x == pt.x && y == pt.y && z == pt.z);
-    }
+    bool operator==(const Point3D pt) const { return (x == pt.x && y == pt.y && z == pt.z); }
+
     /// Not equal operator
-    bool operator!=(const Point3D pt) const {
-		
-      return !(*this==pt);
-    }
+    bool operator!=(const Point3D pt) const { return !(*this==pt); }
     
-   bool operator<(const Point3D  _rhs) const{
-      return x < _rhs.x || (!(_rhs.x < x)&& y < _rhs.y)
-			||(!(_rhs.x < x)&& !(_rhs.y <y )&& z < _rhs.z);
-   }
-    //// Begin XMLSerializable interface
-    //virtual void readXML(XMLPullParser &in);
-    //virtual void writeXML(XMLSerializer &out);
-    //// End XMLSerializable interface
+    bool operator<(const Point3D  _rhs) const;
     
     friend std::ostream &operator<<(std::ostream &stream, const Point3D &pt);
   };
+
+  inline Point3D &Point3D::operator=(const Point3D pt) {
+    x = pt.x;
+    y = pt.y;
+    z = pt.z;
+    return *this;
+  }
+
+  inline Point3D &Point3D::operator+=(const Point3D pt) {
+    x += pt.x;
+    y += pt.y;
+    z += pt.z;
+    return *this;
+  }
+
+  inline Point3D &Point3D::operator-=(const Point3D pt) {
+    x -= pt.x;
+    y -= pt.y;
+    z -= pt.z;
+    return *this;
+  }
+
+  inline bool Point3D::operator<(const Point3D  _rhs) const {
+    return x < _rhs.x || (!(_rhs.x < x)&& y < _rhs.y)
+    ||(!(_rhs.x < x)&& !(_rhs.y <y )&& z < _rhs.z);
+  }
 
   /** 
    * Print a Point3D to a std::ostream.

--- a/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/CompuCell.i
@@ -281,9 +281,12 @@ using namespace CompuCell3D;
     def __setstate__(self,tup):
         print( 'tuple=',tup)
         self.this = _CompuCell.new_Point3D(tup[0],tup[1],tup[2])
-        self.thisown=1            
-	
-%}   
+        self.thisown=1
+
+    def to_tuple(self):
+        return self.x, self.y, self.z
+
+%}
 };
 
 
@@ -293,6 +296,13 @@ using namespace CompuCell3D;
     s<<(*self);
     return s.str();
   }
+
+%pythoncode %{
+    def to_tuple(self):
+        return self.x, self.y, self.z
+
+%}
+
 };
 
 %include <Utils/Coordinates3D.h>


### PR DESCRIPTION
Adds simple method to python interface for Point3D and Dim3D to return components as a tuple. Reworked from #447. Closes #446. 