### PR TITLE
Fixed behavior of unzipper - now it correctly identifies *.cc3d file …

### DIFF
--- a/cc3d/gui_plugins/unzipper.py
+++ b/cc3d/gui_plugins/unzipper.py
@@ -46,7 +46,7 @@ class Unzipper:
         with ZipFile(file_name_path, 'r') as zip_file:
             zip_file.extractall(unzip_dirname)
 
-        cc3d_file_path_glob = glob(join(str(unzip_dirname), '**.cc3d'))
+        cc3d_file_path_glob = glob(join(str(unzip_dirname), '**/*.cc3d'), recursive=True)
         if len(cc3d_file_path_glob) != 1:
             QMessageBox.warning(self.__ui, 'Could not uniquely identify .cc3d project',
                                 f'Could not uniquely identify a <b>.cc3d</b> project in the unzipped folder:  '


### PR DESCRIPTION
…regardless if the zip was created using Twedit++ or external program that uses different directory layout. Still, if two or more *.cc3d files are present in the *.zip CC3d will complain

Addresses https://github.com/CompuCell3D/CompuCell3D/issues/473

This PR fixes issue reported by @tjsego  that CC3D was unable to identify *.cc3d files in unzipped folder