### PR TITLE
Added simulation name validation in wizard

### DIFF
--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -894,6 +894,12 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
                                     QMessageBox.Ok)
                 return False
 
+            elif not name.isidentifier():
+                QMessageBox.warning(self, "Invalid simulation name",
+                                    "Please specify a name with no spaces that begins with a letter or '_'",
+                                    QMessageBox.Ok)
+                return False
+
             else:
                 if directory != "":
                     self.plugin.configuration.setSetting("RecentNewProjectDir", directory)

--- a/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
+++ b/cc3d/twedit5/Plugins/CC3DProject/NewSimulationWizard.py
@@ -895,9 +895,13 @@ class NewSimulationWizard(QWizard, ui_newsimulationwizard.Ui_NewSimulationWizard
                 return False
 
             elif not name.isidentifier():
-                QMessageBox.warning(self, "Invalid simulation name",
-                                    "Please specify a name with no spaces that begins with a letter or '_'",
-                                    QMessageBox.Ok)
+                msg = """
+                Please specifying a name that meets with following criteria
+                
+                1. Consists only of letters, numbers and/or `_`. 
+                2. Starts with either a letter or '_'
+                """
+                QMessageBox.warning(self, "Invalid simulation name", msg, QMessageBox.Ok)
                 return False
 
             else:


### PR DESCRIPTION
Wizard derives the name of a generated steppable from the simulation name, which puts constraints on valid simulation names. This PR addresses this issue by validating the simulation name and providing feedback to the user on error. 

Closes #465. 