### PR TITLE
added utility functions to support "pause at" functionality fin the P…

### DIFF
--- a/cc3d/CompuCellSetup/persistent_globals.py
+++ b/cc3d/CompuCellSetup/persistent_globals.py
@@ -71,6 +71,9 @@ class PersistentGlobals:
 
         self.persistent_holder = {}
 
+        # list of MCS at which player will pause
+        self.pause_at = []
+
         self.global_sbml_simulator_options = None
         self.free_floating_sbml_simulators = {}
 

--- a/cc3d/CompuCellSetup/simulation_utils.py
+++ b/cc3d/CompuCellSetup/simulation_utils.py
@@ -1,6 +1,7 @@
 from cc3d import CompuCellSetup
 from cc3d.core.XMLUtils import CC3DXMLListPy
 from pathlib import Path
+from typing import List
 
 
 class CC3DCPlusPlusError(Exception):
@@ -133,3 +134,27 @@ def extract_type_id_type_name_dict(cell_types_elements):
 def check_for_cpp_errors(sim):
     if sim.getRecentErrorMessage() != "":
         raise CC3DCPlusPlusError(sim.getRecentErrorMessage())
+
+
+def str_to_int_list(s: str) -> List[str]:
+    """
+    Converts string - comma separated sequence of integers into list of integers.
+    :param s:
+    :return:
+    """
+
+    s = s.replace(" ", "")
+    s = s.split(",")
+
+    def val_check(inv_val_str):
+        try:
+            int_val = int(inv_val_str)
+        except ValueError:
+            return False
+        return True
+
+    list_int = [int(val) for val in s if val_check(val)]
+
+    return list_int
+
+


### PR DESCRIPTION
…layer

This + corresponding PR in cc3d-player adds new feature that allows users to specify a series of MCS stops at which Player will Pause. I also fixed a glitch where player did not render field uppon pause and instead was showing stale configuration from the last time it rendered something (e.g. at last MCS divisible by 10)