### PR TITLE
Implemented generation of cell type and cell id indicator arrays righ…

### DIFF
--- a/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/DiffusionSolverFE.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/DiffusionSolverFE.cpp
@@ -394,6 +394,24 @@ void DiffusionSolverFE<Cruncher>::init(Simulator *_simulator, CC3DXMLElement *_x
     initImpl();
 }
 
+template<class Cruncher>
+void DiffusionSolverFE<Cruncher>::init_cell_type_and_id_arrays() {
+    Point3D pt;
+    for (pt.z = 0; pt.z < fieldDim.z; ++pt.z)
+        for (pt.y = 0; pt.y < fieldDim.y; ++pt.y)
+            for (pt.x = 0; pt.x < fieldDim.x; ++pt.x) {
+                CellG * cell = cellFieldG->getQuick(pt);
+                if (cell) {
+                    h_celltype_field->set(pt, cell->type);
+                    h_cellid_field->set(pt, cell->id);
+                } else {
+                    h_celltype_field->set(pt, 0);
+                    h_cellid_field->set(pt, 0);
+                }
+            }
+
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<class Cruncher>
 void DiffusionSolverFE<Cruncher>::boundaryConditionIndicatorInit() {
@@ -717,6 +735,8 @@ void DiffusionSolverFE<Cruncher>::step(const unsigned int _currentStep) {
     currentStep = _currentStep;
 
     MyTime::Time_t stepBT = MyTime::CTime();
+    // updating cell type and  cell id arrays
+    init_cell_type_and_id_arrays();
     stepImpl(_currentStep);
     m_RDTime += MyTime::ElapsedTime(stepBT, MyTime::CTime());
 

--- a/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/DiffusionSolverFE.h
+++ b/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/DiffusionSolverFE.h
@@ -178,7 +178,7 @@ namespace CompuCell3D {
         virtual void
         boundaryConditionIndicatorInit(); // this function initializes indicator only not the actual boundary conditions used on non-cartesian lattices
         virtual void boundaryConditionInit(int idx);
-
+        void init_cell_type_and_id_arrays();
         bool isBoudaryRegion(int x, int y, int z, Dim3D dim);
 
         unsigned int numberOfFields;

--- a/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.cpp
+++ b/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.cpp
@@ -338,6 +338,25 @@ void ReactionDiffusionSolverFE::init(Simulator *_simulator, CC3DXMLElement *_xml
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ReactionDiffusionSolverFE::init_cell_type_and_id_arrays() {
+    Point3D pt;
+    for (pt.z = 0; pt.z < fieldDim.z; ++pt.z)
+        for (pt.y = 0; pt.y < fieldDim.y; ++pt.y)
+            for (pt.x = 0; pt.x < fieldDim.x; ++pt.x) {
+                CellG * cell = cellFieldG->getQuick(pt);
+                if (cell) {
+                    h_celltype_field->set(pt, cell->type);
+                    h_cellid_field->set(pt, cell->id);
+                } else {
+                    h_celltype_field->set(pt, 0);
+                    h_cellid_field->set(pt, 0);
+                }
+            }
+
+}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void ReactionDiffusionSolverFE::boundaryConditionIndicatorInit() {
 
     // bool detailedBCFlag=bcSpecFlagVec[idx];
@@ -726,6 +745,8 @@ void ReactionDiffusionSolverFE::prepCellTypeField(int idx) {
 void ReactionDiffusionSolverFE::step(const unsigned int _currentStep) {
 
     if (fluctuationCompensator) fluctuationCompensator->applyCorrections();
+
+    init_cell_type_and_id_arrays();
 
     if (scaleSecretion) {
         for (int callIdx = 0; callIdx < maxNumberOfDiffusionCalls; ++callIdx) {

--- a/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.h
+++ b/CompuCell3D/core/CompuCell3D/steppables/PDESolvers/ReactionDiffusionSolverFE.h
@@ -249,6 +249,7 @@ namespace CompuCell3D {
 
         void boundaryConditionInit(int idx);
 
+        void init_cell_type_and_id_arrays();
         //void boundaryConditionInit(ConcentrationField_t *concentrationField);
         bool isBoudaryRegion(int x, int y, int z, Dim3D dim);
 


### PR DESCRIPTION
…t before calling the step function of the steppable. It fixes the staleness of those arrays reported in https://github.com/CompuCell3D/CompuCell3D/issues/575. As of now cell type and cell_id arrays reflect the most recent configuration of the lattice regardless of whether we are using frozen cells or not. The overhead associated with update is small

