### PR TITLE
Minor fixes for MSVC 2019 and python init

### DIFF
--- a/CompuCell3D/core/PublicUtilities/StringUtils.cpp
+++ b/CompuCell3D/core/PublicUtilities/StringUtils.cpp
@@ -1,6 +1,7 @@
 #include "StringUtils.h"
 #include <iostream>
 #include <algorithm>
+#include <string>
 
 using namespace std;
 void parseStringIntoList(std::string &str,std::vector<std::string> &strVec,std::string separator){

--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -72,8 +72,6 @@ if sys.platform.startswith('win'):
 
         if cc3d_lib_shared not in path_env_list:
             os.add_dll_directory(cc3d_lib_shared)
-        if cc3d_cpp_bin_path not in path_env_list:
-            os.add_dll_directory(cc3d_cpp_bin_path)
 
         os.add_dll_directory(os.environ['COMPUCELL3D_PLUGIN_PATH'])
         os.add_dll_directory(os.environ['COMPUCELL3D_STEPPABLE_PATH'])
@@ -82,8 +80,6 @@ if sys.platform.startswith('win'):
 
         if cc3d_lib_shared not in path_env_list:
             path_env_list.insert(0, cc3d_lib_shared)
-        if cc3d_cpp_bin_path not in path_env_list:
-            path_env_list.insert(0, cc3d_cpp_bin_path)
 
         path_env_list.insert(0, os.environ['COMPUCELL3D_PLUGIN_PATH'])
         path_env_list.insert(0, os.environ['COMPUCELL3D_STEPPABLE_PATH'])


### PR DESCRIPTION
I can build with MSVC 2019 using these fixes. Metadata for conda-build would need updated if we upgrade the build pipeline for windows. 