### PR TITLE
minor bugfix bitearray decode OSX

### DIFF
--- a/cc3d/core/Configuration/settingdict.py
+++ b/cc3d/core/Configuration/settingdict.py
@@ -27,7 +27,7 @@ class SerializerUtil(object):
             'bool': lambda val: ('bool', int(val)),
             'Size2D': lambda val: ('size', str(val)),
             'Point2D': lambda val: ('point', str(val)),
-            'bytearray': lambda val: ('bytearray', val.decode(encoding=_enc)),
+            'bytearray': lambda val: ('bytearray', bytes(val)),
             'dict': self.dict_2_sql,
             'list': self.list_2_sql,
             'tuple': self.tuple_2_sql
@@ -45,7 +45,7 @@ class SerializerUtil(object):
             'bool': lambda val: False if int(val) == 0 else True,
             'size': self.sql_2_size,
             'point': self.sql_2_point,
-            'bytearray': lambda val: str(val, encoding=_enc),
+            'bytearray': lambda val: bytes(val),
             'dict': self.sql_2_dict,
             'list': self.sql_2_list,
             'tuple': self.sql_2_tuple,


### PR DESCRIPTION
bitearrays read from _settings.sqlite throw errors

I am on Mac OS X
Installed using mamba

The bitearrays stored in _settings.sqlite for

PlayerSizes
PlayerSizesDefault
PlayerSizesFloating
PlayerSizesFloatingDefault

throw errors and the following is printed to terminal:

`FOUND THE FOLLOWING PROBLEMATIC SETTINGS:  ['PlayerSizes', 'PlayerSizesDefault', 'PlayerSizesFloating', 'PlayerSizesFloatingDefault']`

I believe these errors arise from attempted decoding using.

`'bytearray': lambda val: str(val, encoding=_enc)`

`_enc` is provided by 

`locale.getdefaultlocale()[1]`

This returns:

`'UTF-8'`

The errors desist when modifying 
    CompuCell3D/cc3d/core/Configuration/settingdict.py
by changing

30 `'bytearray': lambda val: ('bytearray', val.decode(encoding=_enc)),`
48  `'bytearray': lambda val: str(val, encoding=_enc),`

to

30 `'bytearray': lambda val: ('bytearray', bytes(val)),`
48 `'bytearray': lambda val: bytes(val),`

These settings are read from 
    cc3d/core/Configuration_settings/osx/_settings.sqlite

The values stored are:

PlayerSizes
X'000000ff00000000fd0000000200000000000001e600000149fc0200000003fb00000016004d006f00640065006c0045006400690074006f0072010000001e0000006b0000005e00fffffffb00000016004c0061007400740069006300650044006100740061010000008a0000007e0000005e00fffffffb0000002800430065006c006c00540079007000650043006f006c006f0072004d00610070005600690065007701000001090000005e0000005e00ffffff00000003000002bf0000007ffc0100000001fb0000000e0043006f006e0073006f006c00650100000000000002bf0000006b00ffffff000000d80000014900000001000000040000000800000008fc0000000100000002000000040000001400530069006d0054006f006f006c0062006100720100000000ffffffff00000000000000000000001600460069006c00650054006f006f006c0062006100720100000091ffffffff00000000000000000000002800560069007300750061006c0069007a006100740069006f006e0054006f006f006c0062006100720100000100ffffffff00000000000000000000001a00570069006e0064006f00770054006f006f006c006200610072010000014dffffffff0000000000000000'
PlayerSizesDefault
X'000000ff00000000fd00000002000000000000012100000162fc0200000002fb00000016004d006f00640065006c0045006400690074006f00720100000031000001620000005b00fffffffb00000016004c0061007400740069006300650044006100740061000000010c000000d70000005b00ffffff00000003000003f4000000cafc0100000001fb0000000e0043006f006e0073006f006c00650100000000000003f40000007f00ffffff000002cf0000016200000001000000040000000800000008fc0000000100000002000000040000001400530069006d0054006f006f006c0062006100720100000000ffffffff00000000000000000000001600460069006c00650054006f006f006c0062006100720100000078ffffffff00000000000000000000002800560069007300750061006c0069007a006100740069006f006e0054006f006f006c00620061007201000000d5ffffffff00000000000000000000001a00570069006e0064006f00770054006f006f006c0062006100720100000117ffffffff0000000000000000'
PlayerSizesFloating
X'000000ff00000000fd0000000200000000000002800000011ffc0200000003fb00000016004d006f00640065006c0045006400690074006f0072010000001e000000b20000005e00fffffffb00000016004c0061007400740069006300650044006100740061000000010c000000d70000005e00fffffffb0000002800430065006c006c00540079007000650043006f006c006f0072004d00610070005600690065007701000000d10000006c0000005e00ffffff000000030000028000000087fc0100000001fb0000000e0043006f006e0073006f006c00650100000000000002800000006b00ffffff000000000000011f00000001000000040000000800000008fc0000000100000002000000040000001400530069006d0054006f006f006c0062006100720100000000ffffffff00000000000000000000001600460069006c00650054006f006f006c0062006100720100000091ffffffff00000000000000000000002800560069007300750061006c0069007a006100740069006f006e0054006f006f006c0062006100720100000100ffffffff00000000000000000000001a00570069006e0064006f00770054006f006f006c006200610072010000014dffffffff0000000000000000'
PlayerSizesFloatingDefault
X'000000ff00000000fd00000002000000000000012100000162fc0200000002fb00000016004d006f00640065006c0045006400690074006f00720100000031000001620000005b00fffffffb00000016004c0061007400740069006300650044006100740061000000010c000000d70000005b00ffffff00000003000003f4000000cafc0100000001fb0000000e0043006f006e0073006f006c00650100000000000003f40000007f00ffffff000002cf0000016200000001000000040000000800000008fc0000000100000002000000040000001400530069006d0054006f006f006c0062006100720100000000ffffffff00000000000000000000001600460069006c00650054006f006f006c0062006100720100000078ffffffff00000000000000000000002800560069007300750061006c0069007a006100740069006f006e0054006f006f006c00620061007201000000d5ffffffff00000000000000000000001a00570069006e0064006f00770054006f006f006c0062006100720100000117ffffffff0000000000000000'

Any reason not to do this?