### PR TITLE
Hotfix/4.4.1.4

### DIFF
--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -10,8 +10,8 @@ from os.path import dirname, join, abspath
 from pathlib import Path
 
 __version__ = "4.4.1"
-__revision__ = "3"
-__githash__ = "ae4c03c"
+__revision__ = "4"
+__githash__ = "c4121fe"
 
 # from . import config
 from cc3d import config

--- a/cc3d/core/GraphicsOffScreen/GenericDrawer.py
+++ b/cc3d/core/GraphicsOffScreen/GenericDrawer.py
@@ -42,7 +42,8 @@ MODULENAME = '---- GraphicsFrameWidget.py: '
 
 class GenericDrawer:
     def __init__(self, boundary_strategy=None):
-
+        # we will do a lazy initialization of the self.ren_win - inside output_screenshot method
+        self.ren_win = None
         self.plane = None
         self.planePos = None
         self.field_extractor = None
@@ -455,8 +456,11 @@ class GenericDrawer:
         """
 
         ren = self.get_renderer()
-        ren_win = vtk.vtkRenderWindow()
-        ren_win.SetOffScreenRendering(1)
+        if self.ren_win is None:
+            self.ren_win = vtk.vtkRenderWindow()
+            self.ren_win.SetOffScreenRendering(1)
+
+        ren_win = self.ren_win
 
         if screenshot_data is not None:
             ren_win.SetSize(screenshot_data.win_width, screenshot_data.win_height)

--- a/cc3d/core/GraphicsOffScreen/GenericDrawer.py
+++ b/cc3d/core/GraphicsOffScreen/GenericDrawer.py
@@ -459,13 +459,13 @@ class GenericDrawer:
         if self.ren_win is None:
             self.ren_win = vtk.vtkRenderWindow()
             self.ren_win.SetOffScreenRendering(1)
+            self.ren_win.AddRenderer(ren)
 
         ren_win = self.ren_win
 
         if screenshot_data is not None:
             ren_win.SetSize(screenshot_data.win_width, screenshot_data.win_height)
 
-        ren_win.AddRenderer(ren)
         ren_win.Render()
 
         window_to_image_filter = vtk.vtkWindowToImageFilter()


### PR DESCRIPTION
This fixes the screenshot issue (context leak and out-of-memory error on OSX). The trick was not to recreate rendering windows each time we output screenshot but create it once and reuse it