### PR TITLE
Feature/restart fix

### DIFF
--- a/cc3d/CompuCellSetup/simulation_setup.py
+++ b/cc3d/CompuCellSetup/simulation_setup.py
@@ -465,15 +465,18 @@ def initialize_cc3d_sim(sim, simthread):
     init_using_restart_snapshot_enabled = restart_manager.restart_enabled()
     sim.setRestartEnabled(init_using_restart_snapshot_enabled)
 
+    extra_init_simulation_objects(sim, simthread,
+                                  init_using_restart_snapshot_enabled=init_using_restart_snapshot_enabled)
+
+    check_for_cpp_errors(CompuCellSetup.persistent_globals.simulator)
+
+
     if init_using_restart_snapshot_enabled:
         print('WILL RESTART SIMULATION')
         restart_manager.loadRestartFiles()
         check_for_cpp_errors(CompuCellSetup.persistent_globals.simulator)
     else:
         print('WILL RUN SIMULATION FROM BEGINNING')
-
-    extra_init_simulation_objects(sim, simthread,
-                                  init_using_restart_snapshot_enabled=init_using_restart_snapshot_enabled)
 
     check_for_cpp_errors(CompuCellSetup.persistent_globals.simulator)
 

--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -10,8 +10,8 @@ from os.path import dirname, join, abspath
 from pathlib import Path
 
 __version__ = "4.4.1"
-__revision__ = "3"
-__githash__ = "ae4c03c"
+__revision__ = "4"
+__githash__ = "c4121fe"
 
 # from . import config
 from cc3d import config

--- a/cc3d/core/GraphicsOffScreen/GenericDrawer.py
+++ b/cc3d/core/GraphicsOffScreen/GenericDrawer.py
@@ -42,7 +42,8 @@ MODULENAME = '---- GraphicsFrameWidget.py: '
 
 class GenericDrawer:
     def __init__(self, boundary_strategy=None):
-
+        # we will do a lazy initialization of the self.ren_win - inside output_screenshot method
+        self.ren_win = None
         self.plane = None
         self.planePos = None
         self.field_extractor = None
@@ -455,13 +456,16 @@ class GenericDrawer:
         """
 
         ren = self.get_renderer()
-        ren_win = vtk.vtkRenderWindow()
-        ren_win.SetOffScreenRendering(1)
+        if self.ren_win is None:
+            self.ren_win = vtk.vtkRenderWindow()
+            self.ren_win.SetOffScreenRendering(1)
+            self.ren_win.AddRenderer(ren)
+
+        ren_win = self.ren_win
 
         if screenshot_data is not None:
             ren_win.SetSize(screenshot_data.win_width, screenshot_data.win_height)
 
-        ren_win.AddRenderer(ren)
         ren_win.Render()
 
         window_to_image_filter = vtk.vtkWindowToImageFilter()

--- a/cc3d/core/RestartManager.py
+++ b/cc3d/core/RestartManager.py
@@ -1765,11 +1765,11 @@ class RestartManager:
                 chd_dict['saturationCoef'] = chd.saturationCoef
                 chd_dict['formulaName'] = chd.formulaName
                 chemotactTowardsVec = chd.getChemotactTowardsVectorTypes()
-                print('chemotactTowardsVec=', chemotactTowardsVec)
+                # print('chemotactTowardsVec=', chemotactTowardsVec)
                 chd_dict['chemotactTowardsTypesVec'] = chd.getChemotactTowardsVectorTypes()
 
                 pickle.dump(chd_dict, pf)
-            print('field_names=', field_names)
+            # print('field_names=', field_names)
             # cPickle.dump(cellAdhesionVector,pf)        
 
         pf.close()


### PR DESCRIPTION
This is a short PR that fixes simulation restart - extraInit was not called before loading of the restart files which caused some plugins e.g. PixelTracker or BoundaryPixelTracker segfault because they were not fully initialized