### PR TITLE
Fixing issue with attaching Python dictionary to Link objects. For so…

### DIFF
--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityLinks.h
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityLinks.h
@@ -193,14 +193,6 @@ namespace CompuCell3D {
         PyObject *pyAttrib;
 
         PyObject *getPyAttrib() {
-//#ifdef SWIG
-//            if (pyAttrib == nullptr){
-//                PyGILState_STATE gstate;
-//                gstate = PyGILState_Ensure();
-//                pyAttrib = PyDict_New();
-//                PyGILState_Release(gstate);
-//            }
-//#endif
             return pyAttrib;
         }
     };

--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityLinks.h
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityLinks.h
@@ -193,9 +193,14 @@ namespace CompuCell3D {
         PyObject *pyAttrib;
 
         PyObject *getPyAttrib() {
-#ifdef SWIGPYTHON
-            if (pyAttrib == nullptr) pyAttrib = PyDict_New();
-#endif
+//#ifdef SWIG
+//            if (pyAttrib == nullptr){
+//                PyGILState_STATE gstate;
+//                gstate = PyGILState_Ensure();
+//                pyAttrib = PyDict_New();
+//                PyGILState_Release(gstate);
+//            }
+//#endif
             return pyAttrib;
         }
     };

--- a/CompuCell3D/core/pyinterface/CompuCellPython/CompuCellExtraDeclarations.i
+++ b/CompuCell3D/core/pyinterface/CompuCellPython/CompuCellExtraDeclarations.i
@@ -403,6 +403,13 @@ namespace swig{
 
 %inline %{
    PyObject* getLinkPyAttrib(CompuCell3D::FocalPointPlasticityLinkBase* _link){
+            if (_link->pyAttrib == nullptr){
+                PyGILState_STATE gstate;
+                gstate = PyGILState_Ensure();
+                _link->pyAttrib = PyDict_New();
+                PyGILState_Release(gstate);
+            }
+
         PyObject* pyAttrib = _link->getPyAttrib();
         Py_INCREF(pyAttrib);
         return pyAttrib;

--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -73,8 +73,8 @@ if sys.platform.startswith('win'):
 
     if sys.version_info >= (3, 8):
 
-        if cc3d_lib_shared not in path_env_list:
-            os.add_dll_directory(cc3d_lib_shared)
+        # if cc3d_lib_shared not in path_env_list:
+        #     os.add_dll_directory(cc3d_lib_shared)
 
         os.add_dll_directory(os.environ['COMPUCELL3D_PLUGIN_PATH'])
         os.add_dll_directory(os.environ['COMPUCELL3D_STEPPABLE_PATH'])

--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -10,8 +10,8 @@ from os.path import dirname, join, abspath
 from pathlib import Path
 
 __version__ = "4.4.1"
-__revision__ = "4"
-__githash__ = "c4121fe"
+__revision__ = "6"
+__githash__ = "613b379"
 
 # from . import config
 from cc3d import config


### PR DESCRIPTION
…me reason #ifdef SWIGPYTHON macro did not work with swig 4.0. I moved dictionary creation to CompuCellExtraDeclarations.i.