### PR TITLE
Fixed missing outputPath when no movies were made

### DIFF
--- a/cc3d/core/GraphicsUtils/MovieCreator.py
+++ b/cc3d/core/GraphicsUtils/MovieCreator.py
@@ -23,6 +23,7 @@ def makeMovie(simulationPath, frameRate, quality, enableDrawingMCS=True):
 
     print("Making movie inside `", simulationPath, "`")
     movieCount = 0
+    outputPath = None
 
     for visualizationName in sorted(os.listdir(simulationPath)):
         inputPath = os.path.join(simulationPath, visualizationName)


### PR DESCRIPTION
Fixes the following bug:

```
Making movie inside ` C:\path\Compartments_cc3d_11_28_2023_11_16_13 `
Created 0 movies inside `C:\path\Compartments_cc3d_11_28_2023_11_16_13` with frame rate 2 and quality 7/51.
Traceback (most recent call last):
  File "C:\ProgramData\miniconda3\envs\cc3d_4413_310\lib\site-packages\cc3d\player5\Plugins\ViewManagerPlugins\SimpleTabView.py", line 1643, in handleAutomaticMovie
    makeMovieWithSettings()
  File "C:\ProgramData\miniconda3\envs\cc3d_4413_310\lib\site-packages\cc3d\player5\Plugins\ViewManagerPlugins\MovieMediator.py", line 24, in makeMovieWithSettings
    numMoviesMade, moviePath = makeMovie(simulationPath, frameRate, quality, writeText)
  File "C:\ProgramData\miniconda3\envs\cc3d_4413_310\lib\site-packages\cc3d\core\GraphicsUtils\MovieCreator.py", line 106, in makeMovie
    return movieCount, outputPath
UnboundLocalError: local variable 'outputPath' referenced before assignment
```