### PR TITLE
Add on-demand lattice snapshots to Python API

### DIFF
--- a/cc3d/CompuCellSetup/CC3DPy.py
+++ b/cc3d/CompuCellSetup/CC3DPy.py
@@ -79,6 +79,22 @@ class CC3DPy:
         CompuCellSetup.store_screenshots(cur_step=current_step)
 
     @staticmethod
+    def store_lattice_snapshot(mcs: int, output_dir_name: str = None, output_file_core_name: str = None) -> bool:
+        """
+        Store a lattice snapshot on demand
+
+        :param mcs: current step
+        :param output_dir_name: override output directory
+        :param output_file_core_name: override output file core name
+        :return: True on success
+        """
+        cml_field_handler = CompuCellSetup.persistent_globals.cml_field_handler
+        if cml_field_handler:
+            cml_field_handler.write_fields(mcs, output_dir_name, output_file_core_name)
+            return True
+        return False
+
+    @staticmethod
     def check_cc3d():
         try:
             CompuCellSetup.check_for_cpp_errors(CompuCellSetup.persistent_globals.simulator)

--- a/cc3d/CompuCellSetup/persistent_globals.py
+++ b/cc3d/CompuCellSetup/persistent_globals.py
@@ -221,6 +221,13 @@ class PersistentGlobals:
 
             return self.__output_dir
 
+    @property
+    def output_dir(self) -> Union[str, None]:
+        """
+        Raw value of output directory
+        """
+        return self.__output_dir
+
     def create_output_dir(self):
         """
 

--- a/cc3d/core/simservice/CC3DSimService.py
+++ b/cc3d/core/simservice/CC3DSimService.py
@@ -252,6 +252,15 @@ class CC3DSimService(CC3DPySim, PySimService):
             self._error_message = cc3d_cpp_err.message
             return False
 
+    def store_lattice_snapshot(self, output_dir_name: str = None, output_file_core_name: str = None):
+        """
+        Store a lattice snapshot on demand
+        :param output_dir_name: override output directory
+        :param output_file_core_name: override output file core name
+        :return: True on success
+        """
+        return CC3DPy.store_lattice_snapshot(self.current_step, output_dir_name, output_file_core_name)
+
     @property
     def profiler_report(self) -> str:
         steppable_registry = CompuCellSetup.persistent_globals.steppable_registry


### PR DESCRIPTION
Doesn't seem to affect Player, but additional testing would be appreciated. 