### PR TITLE
fixing CMLResultsReader.py - in particular implementing the workaroun…

### DIFF
--- a/cc3d/__init__.py
+++ b/cc3d/__init__.py
@@ -10,8 +10,8 @@ from os.path import dirname, join, abspath
 from pathlib import Path
 
 __version__ = "4.5.0"
-__revision__ = "2"
-__githash__ = "f8ddda9"
+__revision__ = "6"
+__githash__ = "8190091"
 
 # from . import config
 from cc3d import config

--- a/cc3d/core/CMLResultsReader.py
+++ b/cc3d/core/CMLResultsReader.py
@@ -137,9 +137,11 @@ class LatticeDataSummaryReader:
     def extract_cell_type_cpp_info_from_file_name(_lds_file: str) -> CC3DXML.MapIntStr:
         _lds_file = LatticeDataSummaryReader.lds_file_check(_lds_file)
         type_id_type_name_dict = LatticeDataSummaryReader.extract_cell_type_info_from_file_name(_lds_file)
-        type_id_type_name_cpp_map = CC3DXML.MapIntStr()
-        for type_id in list(type_id_type_name_dict.keys()):
-            type_id_type_name_cpp_map[int(type_id)] = type_id_type_name_dict[type_id]
+        type_id_type_name_cpp_map = CC3DXML.MapIntStr(
+            {int(type_id):type_id_type_name_dict[type_id] for type_id in list(type_id_type_name_dict.keys()) }
+        )
+        # for type_id in list(type_id_type_name_dict.keys()):
+        #     type_id_type_name_cpp_map[int(type_id)] = type_id_type_name_dict[type_id]
         return type_id_type_name_cpp_map
 
     @staticmethod

--- a/cc3d/core/CMLResultsReader.py
+++ b/cc3d/core/CMLResultsReader.py
@@ -140,8 +140,7 @@ class LatticeDataSummaryReader:
         type_id_type_name_cpp_map = CC3DXML.MapIntStr(
             {int(type_id):type_id_type_name_dict[type_id] for type_id in list(type_id_type_name_dict.keys()) }
         )
-        # for type_id in list(type_id_type_name_dict.keys()):
-        #     type_id_type_name_cpp_map[int(type_id)] = type_id_type_name_dict[type_id]
+
         return type_id_type_name_cpp_map
 
     @staticmethod


### PR DESCRIPTION
…d for SWIG-generated map<int, str> wrapper inside extract_cell_type_cpp_info_from_file_name. Addresses https://github.com/CompuCell3D/CompuCell3D/issues/712

Fixing user-reported error