### PR TITLE
Fixed a random segmentation fault that occurred when end-cell, part o…

### DIFF
--- a/CompuCell3D/core/CompuCell3D/plugins/Curvature/CurvaturePlugin.cpp
+++ b/CompuCell3D/core/CompuCell3D/plugins/Curvature/CurvaturePlugin.cpp
@@ -887,19 +887,20 @@ void CurvaturePlugin::field3DChange(const Point3D &pt, CellG *newCell, CellG *ol
             oldCellNeighborVec.push_back(make_pair(sitr->neighborAddress, oldCellNeighbor));
             curvatureNeighborsRemovedNeighbor.erase(CurvatureTrackerData(oldCell));
         }
-
-        oldCellNeighborVec[0].second.neighborAddress = oldCellNeighborVec[1].first;
-        //std::set<CurvatureTrackerData> & curvatureNeighbor_0=
-
-
-        curvatureTrackerAccessor.get(oldCellNeighborVec[0].first->extraAttribPtr)->internalCurvatureNeighbors.insert(
-                oldCellNeighborVec[0].second);
-
-        oldCellNeighborVec[1].second.neighborAddress = oldCellNeighborVec[0].first;
-
-        /*std::set<CurvatureTrackerData> & curvatureNeighbor_1=*/
-        curvatureTrackerAccessor.get(oldCellNeighborVec[1].first->extraAttribPtr)->internalCurvatureNeighbors.insert(
-                oldCellNeighborVec[1].second);
+//        // this part of the code tries to establish links between  two old cell neighbors - but perhaps it is best not
+//        // to do this at all
+//        oldCellNeighborVec[0].second.neighborAddress = oldCellNeighborVec[1].first;
+//        //std::set<CurvatureTrackerData> & curvatureNeighbor_0=
+//
+//
+//        curvatureTrackerAccessor.get(oldCellNeighborVec[0].first->extraAttribPtr)->internalCurvatureNeighbors.insert(
+//                oldCellNeighborVec[0].second);
+//
+//        oldCellNeighborVec[1].second.neighborAddress = oldCellNeighborVec[0].first;
+//
+//        /*std::set<CurvatureTrackerData> & curvatureNeighbor_1=*/
+//        curvatureTrackerAccessor.get(oldCellNeighborVec[1].first->extraAttribPtr)->internalCurvatureNeighbors.insert(
+//                oldCellNeighborVec[1].second);
 
 
     }


### PR DESCRIPTION
…f a cluster connected via curvature links disappeared. The code tried to establish links between neighbors of the disappearing cells, and it assumed that there were two neighbors, but in reality for end-cell there is only one. I turned off this code. If the "middle" cell disappears, we do not try to link two fragments together. I think this makes more sense

Here is the illustration:
![image](https://github.com/user-attachments/assets/88af3824-e11e-40f9-a08c-bd4ee1da232e)
When the green cell disappears the code tries to establish a link between two neighbors but in reality, there is only one link. This led to seg fault. 