### PR TITLE
Added override for max number of links a given cell type can form

### DIFF
--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.cpp
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.cpp
@@ -91,12 +91,13 @@ void FocalPointPlasticityPlugin::update(CC3DXMLElement *_xmlData, bool _fullInit
                 "CELL TYPE PLUGIN WAS NOT PROPERLY INITIALIZED YET. MAKE SURE THIS IS THE FIRST PLUGIN THAT YOU SET");
 
     CC3DXMLElementList maxTotalNumberOfLinksOverrideVec = _xmlData->getElements("MaxTotalNumberOfLinks");
-    CC3DXMLElementList maxTotalNumberOfLinksInternalOverrideVec = _xmlData->getElements("InternalMaxTotalNumberOfLinks");
+    CC3DXMLElementList internalMaxTotalNumberOfLinksOverrideVec = _xmlData->getElements("InternalMaxTotalNumberOfLinks");
 
     // parsing entries fo the type: <MaxTotalNumberOfLinks CellType="Condensing">2</MaxTotalNumberOfLinks>
     maxTotalNumberOfLinksOverrideMap.clear();
     for (auto & xmlElem : maxTotalNumberOfLinksOverrideVec) {
         unsigned char cellType = automaton->getTypeId(xmlElem->getAttribute("CellType"));
+
         int maxTotalLinks = xmlElem->getInt();
         maxTotalNumberOfLinksOverrideMap[cellType] = maxTotalLinks;
 
@@ -104,7 +105,7 @@ void FocalPointPlasticityPlugin::update(CC3DXMLElement *_xmlData, bool _fullInit
 
     // parsing entries fo the type: <InternalMaxTotalNumberOfLinks CellType="Condensing">2</InternalMaxTotalNumberOfLinks>
     maxTotalNumberOfLinksInternalOverrideMap.clear();
-    for (auto & xmlElem : maxTotalNumberOfLinksInternalOverrideVec) {
+    for (auto & xmlElem : internalMaxTotalNumberOfLinksOverrideVec) {
         unsigned char cellType = automaton->getTypeId(xmlElem->getAttribute("CellType"));
         int maxTotalLinks = xmlElem->getInt();
         maxTotalNumberOfLinksInternalOverrideMap[cellType] = maxTotalLinks;

--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.cpp
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.cpp
@@ -91,7 +91,7 @@ void FocalPointPlasticityPlugin::update(CC3DXMLElement *_xmlData, bool _fullInit
                 "CELL TYPE PLUGIN WAS NOT PROPERLY INITIALIZED YET. MAKE SURE THIS IS THE FIRST PLUGIN THAT YOU SET");
 
     CC3DXMLElementList maxTotalNumberOfLinksOverrideVec = _xmlData->getElements("MaxTotalNumberOfLinks");
-    CC3DXMLElementList maxTotalNumberOfLinksInternalOverrideVec = _xmlData->getElements("MaxTotalNumberOfLinksInternal");
+    CC3DXMLElementList maxTotalNumberOfLinksInternalOverrideVec = _xmlData->getElements("InternalMaxTotalNumberOfLinks");
 
     // parsing entries fo the type: <MaxTotalNumberOfLinks CellType="Condensing">2</MaxTotalNumberOfLinks>
     maxTotalNumberOfLinksOverrideMap.clear();
@@ -102,7 +102,7 @@ void FocalPointPlasticityPlugin::update(CC3DXMLElement *_xmlData, bool _fullInit
 
     }
 
-    // parsing entries fo the type: <MaxTotalNumberOfLinksInternal CellType="Condensing">2</MaxTotalNumberOfLinksInternal>
+    // parsing entries fo the type: <InternalMaxTotalNumberOfLinks CellType="Condensing">2</InternalMaxTotalNumberOfLinks>
     maxTotalNumberOfLinksInternalOverrideMap.clear();
     for (auto & xmlElem : maxTotalNumberOfLinksInternalOverrideVec) {
         unsigned char cellType = automaton->getTypeId(xmlElem->getAttribute("CellType"));
@@ -219,7 +219,7 @@ void FocalPointPlasticityPlugin::update(CC3DXMLElement *_xmlData, bool _fullInit
         maxNumberOfJunctionsInternalTotalMap[itr.first] = mNJ;
     }
     // applying override for total internal links from elements of the type
-    // <MaxTotalNumberOfLinksInternal CellType="Condensing">2</MaxTotalNumberOfLinksInternal>
+    // <InternalMaxTotalNumberOfLinks CellType="Condensing">2</InternalMaxTotalNumberOfLinks>
     for (auto &itr: maxTotalNumberOfLinksInternalOverrideMap){
         maxNumberOfJunctionsInternalTotalMap[itr.first] = itr.second;
     }

--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.h
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.h
@@ -114,6 +114,14 @@ namespace CompuCell3D {
 
         std::unordered_map<unsigned char, int> maxNumberOfJunctionsTotalMap;
         std::unordered_map<unsigned char, int> maxNumberOfJunctionsInternalTotalMap;
+
+        // those containers keep track of additional override that users my impose
+        // using <MaxTotalNumberOfLinks CellType="Condensing">2</MaxTotalNumberOfLinks>
+        // or <MaxTotalNumberOfLinksInternal CellType="Condensing">2</MaxTotalNumberOfLinksInternal>
+        std::unordered_map<unsigned char, int> maxTotalNumberOfLinksOverrideMap;
+        std::unordered_map<unsigned char, int> maxTotalNumberOfLinksInternalOverrideMap;
+
+
         int neighborOrder;
 
     public:

--- a/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.h
+++ b/CompuCell3D/core/CompuCell3D/plugins/FocalPointPlasticity/FocalPointPlasticityPlugin.h
@@ -117,7 +117,7 @@ namespace CompuCell3D {
 
         // those containers keep track of additional override that users my impose
         // using <MaxTotalNumberOfLinks CellType="Condensing">2</MaxTotalNumberOfLinks>
-        // or <MaxTotalNumberOfLinksInternal CellType="Condensing">2</MaxTotalNumberOfLinksInternal>
+        // or <InternalMaxTotalNumberOfLinks CellType="Condensing">2</InternalMaxTotalNumberOfLinks>
         std::unordered_map<unsigned char, int> maxTotalNumberOfLinksOverrideMap;
         std::unordered_map<unsigned char, int> maxTotalNumberOfLinksInternalOverrideMap;
 


### PR DESCRIPTION
This PR adds an additional feature and an XML tag but does not alter how FPP plugin works if you use "legacy" syntax

This is an additional feature for the FPP plugin that allows overriding a default algorithm that determines how many links a given cell type can form. For example currently when we specify FPP plugin as follows:

```xml
    <Plugin Name="FocalPointPlasticity">

        <InternalParameters Type1="Top" Type2="Center">
            <Lambda>100.0</Lambda>
            <ActivationEnergy>-50.0</ActivationEnergy>
            <TargetDistance>5</TargetDistance>
            <MaxDistance>10.0</MaxDistance>
            <MaxNumberOfJunctions>1</MaxNumberOfJunctions>
        </InternalParameters>

        <InternalParameters Type1="Center" Type2="Center">
            <Lambda>100.0</Lambda>
            <ActivationEnergy>-50.0</ActivationEnergy>
            <TargetDistance>5</TargetDistance>
            <MaxDistance>10.0</MaxDistance>
            <MaxNumberOfJunctions>2</MaxNumberOfJunctions>
        </InternalParameters>

   </Plugin>
```

the ``Center`` cells can form a total 3 links - 2 between themselves and 1 with the ``Top`` cell. This has a side effect that  in the elongated cells simulation we start :

![image](https://github.com/user-attachments/assets/8e0762b4-eba5-42ca-962b-96b1dd242945)

but may end up with center cells forming a "triangle of links" which is undesirable:
![image](https://github.com/user-attachments/assets/fd04f6a2-b579-451b-a9e4-c3af694b0c1a)

This PR adds 

the option to override max total number of links that cells of a given type can form:
``<InternalMaxTotalNumberOfLinks CellType="Center">2</InternalMaxTotalNumberOfLinks>``

so that we can have FPP plugin definition with the folliwing syntax:

```xml
    <Plugin Name="FocalPointPlasticity">

        <InternalParameters Type1="Top" Type2="Center">
            <Lambda>100.0</Lambda>
            <ActivationEnergy>-50.0</ActivationEnergy>
            <TargetDistance>5</TargetDistance>
            <MaxDistance>10.0</MaxDistance>
            <MaxNumberOfJunctions>1</MaxNumberOfJunctions>
        </InternalParameters>

        <InternalParameters Type1="Center" Type2="Center">
            <Lambda>100.0</Lambda>
            <ActivationEnergy>-50.0</ActivationEnergy>
            <TargetDistance>5</TargetDistance>
            <MaxDistance>10.0</MaxDistance>
            <MaxNumberOfJunctions>2</MaxNumberOfJunctions>
        </InternalParameters>

        <InternalMaxTotalNumberOfLinks CellType="Center">2</internalMaxTotalNumberOfLinks>

   </Plugin>

```

