### PR TITLE
Added FFMPEG as explicit Conda pkg dependency

### DIFF
--- a/cc3d/doc/environment.yml
+++ b/cc3d/doc/environment.yml
@@ -12,4 +12,5 @@ dependencies:
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex
   - graphviz
+  - libfreetype
   - ffmpeg

--- a/cc3d/doc/environment.yml
+++ b/cc3d/doc/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - sphinx_rtd_theme
   - sphinxcontrib-bibtex
   - graphviz
+  - ffmpeg


### PR DESCRIPTION
In this issue, https://github.com/CompuCell3D/CompuCell3D/issues/775, the `drawtext` filter is not found in FFMPEG. According to [this StackOverflow answer](https://stackoverflow.com/a/48037936), it is a result of FFMPEG being installed without the explicit option for this package. This leaves us with two solutions:
1. Install the correct version of ffmpeg with CC3D
2. Recommend users to install ffmpeg manually (e.g. `brew install ffmpeg --with-freetype` or a [Windows installer](https://ffmpeg.org/download.html)), then ask them to adjust the path to their ffmpeg executable in the CC3D Player5 config menu. 

If I run `conda search conda-forge:ffmpeg --info`, I see that `freetype` is a dependency installed with ffmpeg. libfreetype and freetype are essentially just different names for the same package and set of tools, but I have added libfreetype as an explicit dependency to be safe.

The question I have is, does the CC3D Windows installer pull its Python packages from conda-forge? If so, this PR should cover all forms of installation. 