### PR TITLE
Add basic unit test for CompuCellSetup.getCore

### DIFF
--- a/cc3d/tests/test_compucellsetup.py
+++ b/cc3d/tests/test_compucellsetup.py
@@ -1,0 +1,7 @@
+# cc3d/tests/test_compucellsetup.py
+from cc3d.CompuCellSetup import getCore
+
+def test_get_core_returns_object():
+    core = getCore()
+    assert core is not None
+


### PR DESCRIPTION
This PR introduces a basic test to ensure getCore() returns a valid object. Part of improving test coverage for core modules.